### PR TITLE
add SameSite support

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -26,6 +26,7 @@ func NewManager(store Store) *Manager {
 		path:        "/",
 		persist:     false,
 		secure:      false,
+		sameSite:    "",
 	}
 
 	return &Manager{
@@ -95,6 +96,15 @@ func (m *Manager) Persist(b bool) {
 // over HTTPS in production environments.
 func (m *Manager) Secure(b bool) {
 	m.opts.secure = b
+}
+
+// SameSite sets the 'SameSite' attribute on the session cookie. The default value
+// is nil; setting no SameSite attribute. Allowed values are "Lax" and "Strict".
+// Note that "" (empty-string) causes SameSite to NOT be set -- don't confuse this
+// with the cookie's 'SameSite' attribute (without Lax/Strict), which would default
+// to "Strict".
+func (m *Manager) SameSite(s string) {
+	m.opts.sameSite = s
 }
 
 // Load returns the session data for the current request.

--- a/options.go
+++ b/options.go
@@ -17,4 +17,5 @@ type options struct {
 	path        string
 	persist     bool
 	secure      bool
+	sameSite    string
 }

--- a/options_test.go
+++ b/options_test.go
@@ -11,16 +11,19 @@ func TestCookieOptions(t *testing.T) {
 
 	_, _, cookie := testRequest(t, testPutString(manager), "")
 	if strings.Contains(cookie, "Path=/") == false {
-		t.Fatalf("got %q: expected to contain %q", cookie, "Path=/")
+		t.Errorf("got %q: expected to contain %q", cookie, "Path=/")
 	}
 	if strings.Contains(cookie, "Domain=") == true {
-		t.Fatalf("got %q: expected to not contain %q", cookie, "Domain=")
+		t.Errorf("got %q: expected to not contain %q", cookie, "Domain=")
 	}
 	if strings.Contains(cookie, "Secure") == true {
-		t.Fatalf("got %q: expected to not contain %q", cookie, "Secure")
+		t.Errorf("got %q: expected to not contain %q", cookie, "Secure")
 	}
 	if strings.Contains(cookie, "HttpOnly") == false {
-		t.Fatalf("got %q: expected to contain %q", cookie, "HttpOnly")
+		t.Errorf("got %q: expected to contain %q", cookie, "HttpOnly")
+	}
+	if strings.Contains(cookie, "SameSite") == true {
+		t.Errorf("got %q: expected to not contain %q", cookie, "SameSite")
 	}
 
 	manager = NewManager(newMockStore())
@@ -30,25 +33,29 @@ func TestCookieOptions(t *testing.T) {
 	manager.HttpOnly(false)
 	manager.Lifetime(time.Hour)
 	manager.Persist(true)
+	manager.SameSite("Lax")
 
 	_, _, cookie = testRequest(t, testPutString(manager), "")
 	if strings.Contains(cookie, "Path=/foo") == false {
-		t.Fatalf("got %q: expected to contain %q", cookie, "Path=/foo")
+		t.Errorf("got %q: expected to contain %q", cookie, "Path=/foo")
 	}
 	if strings.Contains(cookie, "Domain=example.org") == false {
-		t.Fatalf("got %q: expected to contain %q", cookie, "Domain=example.org")
+		t.Errorf("got %q: expected to contain %q", cookie, "Domain=example.org")
 	}
 	if strings.Contains(cookie, "Secure") == false {
-		t.Fatalf("got %q: expected to contain %q", cookie, "Secure")
+		t.Errorf("got %q: expected to contain %q", cookie, "Secure")
 	}
 	if strings.Contains(cookie, "HttpOnly") == true {
-		t.Fatalf("got %q: expected to not contain %q", cookie, "HttpOnly")
+		t.Errorf("got %q: expected to not contain %q", cookie, "HttpOnly")
 	}
 	if strings.Contains(cookie, "Max-Age=3600") == false {
-		t.Fatalf("got %q: expected to contain %q:", cookie, "Max-Age=86400")
+		t.Errorf("got %q: expected to contain %q:", cookie, "Max-Age=86400")
 	}
 	if strings.Contains(cookie, "Expires=") == false {
-		t.Fatalf("got %q: expected to contain %q:", cookie, "Expires")
+		t.Errorf("got %q: expected to contain %q:", cookie, "Expires")
+	}
+	if strings.Contains(cookie, "SameSite=Lax") == false {
+		t.Errorf("got %q: expected to contain %q", cookie, "SameSite=Lax")
 	}
 
 	manager = NewManager(newMockStore())
@@ -56,10 +63,25 @@ func TestCookieOptions(t *testing.T) {
 
 	_, _, cookie = testRequest(t, testPutString(manager), "")
 	if strings.Contains(cookie, "Max-Age=") == true {
-		t.Fatalf("got %q: expected not to contain %q:", cookie, "Max-Age=")
+		t.Errorf("got %q: expected not to contain %q:", cookie, "Max-Age=")
 	}
 	if strings.Contains(cookie, "Expires=") == true {
-		t.Fatalf("got %q: expected not to contain %q:", cookie, "Expires")
+		t.Errorf("got %q: expected not to contain %q:", cookie, "Expires")
+	}
+
+	manager = NewManager(newMockStore())
+	manager.SameSite("Strict")
+	_, _, cookie = testRequest(t, testPutString(manager), "")
+	if strings.Contains(cookie, "SameSite=Strict") == false {
+		t.Errorf("got %q: expected to contain %q", cookie, "SameSite=Strict")
+	}
+
+	manager = NewManager(newMockStore())
+	// empty string disables
+	manager.SameSite("")
+	_, _, cookie = testRequest(t, testPutString(manager), "")
+	if strings.Contains(cookie, "SameSite") == true {
+		t.Errorf("got %q: expected to not contain %q", cookie, "SameSite")
 	}
 }
 


### PR DESCRIPTION
Note that upstream support is still pending<sup>[0]</sup> (and even when merged, this
will require the latest Go version). So this adds a workaround to allow
for setting SameSite on the cookies used, as per the draft<sup>[1]</sup>.

Also changes the options_test `TestCookieOptions` calls to `t.Errorf`,
since this will run all checks even if one fails. (`t.Fatal[f]` would
stop test execution.)

[0]: https://github.com/golang/go/issues/15867
[1]: https://tools.ietf.org/html/draft-west-first-party-cookies-07