### PR TITLE
{mem,pg}store: hide internals

### DIFF
--- a/stores/memstore/memstore.go
+++ b/stores/memstore/memstore.go
@@ -25,7 +25,7 @@ var errTypeAssertionFailed = errors.New("type assertion failed: could not conver
 // MemStore represents the currently configured session session store. It is essentially
 // a wrapper around a go-cache instance (see https://github.com/patrickmn/go-cache).
 type MemStore struct {
-	*cache.Cache
+	cache *cache.Cache
 }
 
 // New returns a new MemStore instance.
@@ -42,7 +42,7 @@ func New(cleanupInterval time.Duration) *MemStore {
 // Find returns the data for a given session token from the MemStore instance. If the session
 // token is not found or is expired, the returned exists flag will be set to false.
 func (m *MemStore) Find(token string) (b []byte, exists bool, err error) {
-	v, exists := m.Cache.Get(token)
+	v, exists := m.cache.Get(token)
 	if exists == false {
 		return nil, exists, nil
 	}
@@ -58,12 +58,12 @@ func (m *MemStore) Find(token string) (b []byte, exists bool, err error) {
 // Save adds a session token and data to the MemStore instance with the given expiry time.
 // If the session token already exists then the data and expiry time are updated.
 func (m *MemStore) Save(token string, b []byte, expiry time.Time) error {
-	m.Cache.Set(token, b, expiry.Sub(time.Now()))
+	m.cache.Set(token, b, expiry.Sub(time.Now()))
 	return nil
 }
 
 // Delete removes a session token and corresponding data from the MemStore instance.
 func (m *MemStore) Delete(token string) error {
-	m.Cache.Delete(token)
+	m.cache.Delete(token)
 	return nil
 }

--- a/stores/memstore/memstore_test.go
+++ b/stores/memstore/memstore_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFind(t *testing.T) {
 	m := New(time.Minute)
-	m.Cache.Set("session_token", []byte("encoded_data"), 0)
+	m.cache.Set("session_token", []byte("encoded_data"), 0)
 
 	b, found, err := m.Find("session_token")
 	if err != nil {
@@ -37,7 +37,7 @@ func TestFindMissing(t *testing.T) {
 
 func TestFindBadData(t *testing.T) {
 	m := New(time.Minute)
-	m.Cache.Set("session_token", "not_a_byte_slice", 0)
+	m.cache.Set("session_token", "not_a_byte_slice", 0)
 
 	_, _, err := m.Find("session_token")
 	if err != errTypeAssertionFailed {
@@ -53,7 +53,7 @@ func TestSaveNew(t *testing.T) {
 		t.Fatalf("got %v: expected %v", err, nil)
 	}
 
-	v, found := m.Cache.Get("session_token")
+	v, found := m.cache.Get("session_token")
 	if found != true {
 		t.Fatalf("got %v: expected %v", found, true)
 	}
@@ -68,7 +68,7 @@ func TestSaveNew(t *testing.T) {
 
 func TestSaveUpdated(t *testing.T) {
 	m := New(time.Minute)
-	m.Cache.Set("session_token", []byte("encoded_data"), 0)
+	m.cache.Set("session_token", []byte("encoded_data"), 0)
 
 	err := m.Save("session_token", []byte("encoded_data"), time.Now().Add(time.Minute))
 	if err != nil {
@@ -80,7 +80,7 @@ func TestSaveUpdated(t *testing.T) {
 		t.Fatalf("got %v: expected %v", err, nil)
 	}
 
-	v, _ := m.Cache.Get("session_token")
+	v, _ := m.cache.Get("session_token")
 	b, ok := v.([]byte)
 	if ok == false {
 		t.Fatal("could not convert to []byte")
@@ -112,14 +112,14 @@ func TestExpiry(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	m := New(time.Minute)
-	m.Cache.Set("session_token", []byte("encoded_data"), 0)
+	m.cache.Set("session_token", []byte("encoded_data"), 0)
 
 	err := m.Delete("session_token")
 	if err != nil {
 		t.Fatalf("got %v: expected %v", err, nil)
 	}
 
-	_, found := m.Cache.Get("session_token")
+	_, found := m.cache.Get("session_token")
 	if found != false {
 		t.Fatalf("got %v: expected %v", found, false)
 	}


### PR DESCRIPTION
Before, the way `*cache.Cache` and `*sql.DB` were embedded in in
`Memstore` and `PGStore` respectively, a caller could access their
methods. This didn't seem like a clear separation.

Now, only the `Store` interface methods will be public methods of
(*Memstore), and (*PGStore).