### PR TITLE
created Options interface

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -34,6 +34,11 @@ func NewManager(store Store) *Manager {
 	}
 }
 
+// Returns an interface for Options to allow access to private opts properties.
+func (m *Manager) Opts() Options {
+	return m.opts
+}
+
 // Domain sets the 'Domain' attribute on the session cookie. By default it will
 // be set to the domain name that the cookie was issued from.
 func (m *Manager) Domain(s string) {

--- a/options.go
+++ b/options.go
@@ -18,3 +18,46 @@ type options struct {
 	persist     bool
 	secure      bool
 }
+
+type Options interface {
+	Domain() string
+	HttpOnly() bool
+	IdleTimeout() time.Duration
+	Lifetime() time.Duration
+	Name() string
+	Path() string
+	Persist() bool
+	Secure() bool
+}
+
+func (o *options) Domain() string {
+	return o.domain
+}
+
+func (o *options) HttpOnly() bool {
+	return o.httpOnly
+}
+
+func (o *options) IdleTimeout() time.Duration {
+	return o.idleTimeout
+}
+
+func (o *options) Lifetime() time.Duration {
+	return o.lifetime
+}
+
+func (o *options) Name() string {
+	return o.name
+}
+
+func (o *options) Path() string {
+	return o.path
+}
+
+func (o *options) Persist() bool {
+	return o.persist
+}
+
+func (o *options) Secure() bool {
+	return o.secure
+}

--- a/options_test.go
+++ b/options_test.go
@@ -147,3 +147,47 @@ func TestName(t *testing.T) {
 		t.Fatalf("got %q: expected %q", body, "lorem ipsum")
 	}
 }
+
+func TestInterfaceGetters(t *testing.T) {
+	manager := NewManager(newMockStore())
+	manager.Domain("example.org")
+	manager.HttpOnly(false)
+	manager.IdleTimeout(time.Hour)
+	manager.Lifetime(time.Hour)
+	manager.Name("foo")
+	manager.Path("/foo")
+	manager.Persist(true)
+	manager.Secure(true)
+
+	if manager.Opts().Domain() != "example.org" {
+		t.Fatalf("got %q: expected prefix %q", manager.Opts().Domain(), "example.org")
+	}
+
+	if manager.Opts().HttpOnly() != false {
+		t.Fatalf("got %q: expected prefix %q", manager.Opts().HttpOnly(), false)
+	}
+
+	if manager.Opts().IdleTimeout() != time.Hour {
+		t.Fatalf("got %q: expected prefix %q", manager.Opts().IdleTimeout(), time.Hour)
+	}
+
+	if manager.Opts().Lifetime() != time.Hour {
+		t.Fatalf("got %q: expected prefix %q", manager.Opts().Lifetime(), time.Hour)
+	}
+
+	if manager.Opts().Name() != "foo" {
+		t.Fatalf("got %q: expected prefix %q", manager.Opts().Name(), "foo")
+	}
+
+	if manager.Opts().Path() != "/foo" {
+		t.Fatalf("got %q: expected prefix %q", manager.Opts().Path(), "/foo")
+	}
+
+	if manager.Opts().Persist() != true {
+		t.Fatalf("got %q: expected prefix %q", manager.Opts().Persist(), true)
+	}
+
+	if manager.Opts().Secure() != true {
+		t.Fatalf("got %q: expected prefix %q", manager.Opts().Secure(), true)
+	}
+}


### PR DESCRIPTION
`Options` interface exposes the private `options` struct without breaking code, so this is backwards-compatible. Only `getters` are available on the interface. `set` functions could be added later, if desired. The interface is available through the `manager.Opts()` function. Added a single test function that compares against defaults.

* This should satisfy issue #30. 
* `Opts()` allows web frameworks (eg echo) to create middleware that will play nicely with scs. See issues #24 and problems with using wrapping [Use](https://github.com/alexedwards/scs/issues/31#issuecomment-360881538) for echo.

There are two additional commits associated with this pull request. This was actually unintended b/c I began the pull request before the 2nd two commits were added but Github automatically added them to this request. I can try splitting out, if you want.

All three commits are backwards-compatible with the defaults. 

Re. `saved` property to session: helps the backend data store determine stale records. Also required by `TouchWithInterval()` to know if `Touch()` should occur. In order to preserve strict backwards compatibility, I added a `manager.UseSaved()` function. If the `opts.useSaved` value is true, only then will the date be saved in the sessions store. 

Re. `TouchWithInterval`:  limits amount of unnecessary writes to back end data store. This would close #32. 

I have an an echo middleware example but will wait to commit and have that conversation after we can get past these. Thanks!