### PR TITLE
Check for badger.ErrKeyNotFound

### DIFF
--- a/badgerstore/README.md
+++ b/badgerstore/README.md
@@ -67,7 +67,7 @@ Because the token is highly unique, key collisions are not a concern. But if you
 ```go
 db, err := badger.Open(badger.DefaultOptions("tmp/badger"))
 if err != nil {
-  log.Fatal(err)
+	log.Fatal(err)
 }
 defer db.Close()
 

--- a/badgerstore/badgerstore.go
+++ b/badgerstore/badgerstore.go
@@ -38,8 +38,10 @@ func (bs *BadgerStore) Find(token string) ([]byte, bool, error) {
 	defer txn.Discard()
 
 	item, err := txn.Get(key)
-	if err != nil {
+	if err == badger.ErrKeyNotFound {
 		return nil, false, nil
+	} else if err != nil {
+		return nil, false, err
 	}
 
 	data, err := item.ValueCopy(nil)

--- a/badgerstore/badgerstore_test.go
+++ b/badgerstore/badgerstore_test.go
@@ -203,8 +203,10 @@ func TestDelete(t *testing.T) {
 
 	err = db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(store.prefix + "session_token"))
-		if err != nil {
+		if err == badger.ErrKeyNotFound {
 			return nil
+		} else if err != nil {
+			return err
 		}
 		t.Fatalf("got %v: expected %v", item, nil)
 		return nil


### PR DESCRIPTION
While digging into the code of BadgerDB I found that (and how) you can differentiate between "a key is not present in the store" and "an error happened while reading the key". This might be an important catch. I've updated the code accordingly.

Also I found another formatting issue in the readme.