### PR TITLE
Update go-sqlite3 to version v1.14.6

### DIFF
--- a/sqlite3store/go.mod
+++ b/sqlite3store/go.mod
@@ -2,4 +2,4 @@ module github.com/alexedwards/scs/sqlite3store
 
 go 1.12
 
-require github.com/mattn/go-sqlite3 v2.0.3+incompatible
+require github.com/mattn/go-sqlite3 v1.14.6

--- a/sqlite3store/go.sum
+++ b/sqlite3store/go.sum
@@ -1,2 +1,2 @@
-github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=


### PR DESCRIPTION
The [README](https://github.com/mattn/go-sqlite3#go-sqlite3) states that the increase to v2 was an accident.
There were no major changes or features.

The version bump also gets rid of this sqlite3 warning:
```
# github.com/mattn/go-sqlite3
sqlite3-binding.c: In function ‘sqlite3SelectNew’:
sqlite3-binding.c:128049:10: warning: function may return address of local variable [-Wreturn-local-addr]
128049 |   return pNew;
       |          ^~~~
sqlite3-binding.c:128009:10: note: declared here
128009 |   Select standin;
       |          ^~~~~~~
```