### PR TITLE
Ensure all expired tokens are removed per cleanup

### DIFF
--- a/boltstore/boltstore.go
+++ b/boltstore/boltstore.go
@@ -165,7 +165,10 @@ func (bs *BoltStore) deleteExpired() error {
 		return bs.db.Update(func(tx *bbolt.Tx) error {
 			for _, token := range expiredTokens {
 				bucket := tx.Bucket(bucketName)
-				return bucket.Delete([]byte(token))
+				err := bucket.Delete([]byte(token))
+				if err != nil {
+					return err
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
Currently, only one expired token is removed on any given cleanup run. This is because the value of `Bucket.Delete()` is immediately returned when looping over all expired tokens.

This PR fixes this issue and adds a test which verifies the behavior.

PS: I hope this is the intended behavior, I only stumbled upon this repo very recently ;) nice job btw!