### PR TITLE
Prevent gorm from logging a warning when record is not found.

### DIFF
--- a/gormstore/gormstore.go
+++ b/gormstore/gormstore.go
@@ -46,7 +46,7 @@ func NewWithCleanupInterval(db *gorm.DB, cleanupInterval time.Duration) (*GORMSt
 // be set to false.
 func (g *GORMStore) Find(token string) (b []byte, exists bool, err error) {
 	s := &session{}
-	row := g.db.First(s, "token = ? AND expiry >= ?", token, time.Now())
+	row := g.db.Where("token = ? AND expiry >= ?", token, time.Now()).Limit(1).Find(s)
 	if errors.Is(row.Error, gorm.ErrRecordNotFound) {
 		return nil, false, nil
 	} else if row.Error != nil {


### PR DESCRIPTION
When using the `First` function, `gorm` will log that it failed to find a record. Since this case is valid in `scs` it makes no sense to log it. By using different syntax the same functionality is achieved but without the logging.