### PR TITLE
Do not attempt to delete an uncommitted token.

### DIFF
--- a/data.go
+++ b/data.go
@@ -284,9 +284,11 @@ func (s *SessionManager) RenewToken(ctx context.Context) error {
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
 
-	err := s.doStoreDelete(ctx, sd.token)
-	if err != nil {
-		return err
+	if sd.token != "" {
+		err := s.doStoreDelete(ctx, sd.token)
+		if err != nil {
+			return err
+		}
 	}
 
 	newToken, err := generateToken()


### PR DESCRIPTION
For some stores (e.g. firestory) deleting a record that does not exist
might produce an error.