### PR TITLE
Explicitly pin gorm table and column names

### DIFF
--- a/gormstore/gormstore.go
+++ b/gormstore/gormstore.go
@@ -15,9 +15,13 @@ type GORMStore struct {
 }
 
 type session struct {
-	Token  string `gorm:"primary_key;type:varchar(43)"`
-	Data   []byte
-	Expiry time.Time `gorm:"index"`
+	Token  string    `gorm:"column:token;primaryKey;type:varchar(43)"`
+	Data   []byte.   `gorm:"column:data"`
+	Expiry time.Time `gorm:"column:expiry;index"`
+}
+
+func (session) TableName() string {
+        return "sessions"
 }
 
 // New returns a new GORMStore instance, with a background cleanup goroutine

--- a/gormstore/gormstore.go
+++ b/gormstore/gormstore.go
@@ -16,12 +16,12 @@ type GORMStore struct {
 
 type session struct {
 	Token  string    `gorm:"column:token;primaryKey;type:varchar(43)"`
-	Data   []byte.   `gorm:"column:data"`
+	Data   []byte    `gorm:"column:data"`
 	Expiry time.Time `gorm:"column:expiry;index"`
 }
 
 func (session) TableName() string {
-        return "sessions"
+	return "sessions"
 }
 
 // New returns a new GORMStore instance, with a background cleanup goroutine


### PR DESCRIPTION
Without this, the table/column names will be affected by the user's GORM config if they override the NamingStrategy: https://gorm.io/docs/gorm_config.html#NamingStrategy

This will cause some of the queries in this package to fail.