### PR TITLE
[feature/supportUnixTs] added support for unix milli timestamps

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/scs.iml" filepath="$PROJECT_DIR$/.idea/scs.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/scs.iml
+++ b/.idea/scs.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/postgresstore/postgresstore_test.go
+++ b/postgresstore/postgresstore_test.go
@@ -25,12 +25,13 @@ func TestFind(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = db.Exec("INSERT INTO sessions VALUES('session_token', 'encoded_data', current_timestamp + interval '1 minute')")
+	nowPlusMinute := time.Now().UnixMilli() + 60000
+	_, err = db.Exec("INSERT INTO sessions VALUES('session_token', 'encoded_data', $1)", nowPlusMinute)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	p := NewWithCleanupInterval(db, 0)
+	p := NewWithCleanupInterval(db, 0, true)
 
 	b, found, err := p.Find("session_token")
 	if err != nil {
@@ -59,7 +60,7 @@ func TestFindMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := NewWithCleanupInterval(db, 0)
+	p := NewWithCleanupInterval(db, 0, true)
 
 	_, found, err := p.Find("missing_session_token")
 	if err != nil {
@@ -85,7 +86,7 @@ func TestSaveNew(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := NewWithCleanupInterval(db, 0)
+	p := NewWithCleanupInterval(db, 0, true)
 
 	err = p.Commit("session_token", []byte("encoded_data"), time.Now().Add(time.Minute))
 	if err != nil {
@@ -117,12 +118,13 @@ func TestSaveUpdated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = db.Exec("INSERT INTO sessions VALUES('session_token', 'encoded_data', current_timestamp + interval '1 minute')")
+	nowPlusMinute := time.Now().UnixMilli() + 60000
+	_, err = db.Exec("INSERT INTO sessions VALUES('session_token', 'encoded_data', $1)", nowPlusMinute)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	p := NewWithCleanupInterval(db, 0)
+	p := NewWithCleanupInterval(db, 0, true)
 
 	err = p.Commit("session_token", []byte("new_encoded_data"), time.Now().Add(time.Minute))
 	if err != nil {
@@ -155,7 +157,7 @@ func TestExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := NewWithCleanupInterval(db, 0)
+	p := NewWithCleanupInterval(db, 0, true)
 
 	err = p.Commit("session_token", []byte("encoded_data"), time.Now().Add(100*time.Millisecond))
 	if err != nil {
@@ -188,12 +190,13 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = db.Exec("INSERT INTO sessions VALUES('session_token', 'encoded_data', current_timestamp + interval '1 minute')")
+	nowPlusMinute := time.Now().UnixMilli() + 60000
+	_, err = db.Exec("INSERT INTO sessions VALUES('session_token', 'encoded_data', $1)", nowPlusMinute)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	p := NewWithCleanupInterval(db, 0)
+	p := NewWithCleanupInterval(db, 0, true)
 
 	err = p.Delete("session_token")
 	if err != nil {
@@ -226,7 +229,7 @@ func TestCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := NewWithCleanupInterval(db, 200*time.Millisecond)
+	p := NewWithCleanupInterval(db, 200*time.Millisecond, true)
 	defer p.StopCleanup()
 
 	err = p.Commit("session_token", []byte("encoded_data"), time.Now().Add(100*time.Millisecond))
@@ -266,7 +269,7 @@ func TestStopNilCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := NewWithCleanupInterval(db, 0)
+	p := NewWithCleanupInterval(db, 0, true)
 	time.Sleep(100 * time.Millisecond)
 	// A send to a nil channel will block forever
 	p.StopCleanup()


### PR DESCRIPTION
Tests altered to use unix milli timestamps for now. Would have to recreate sessions table schema to run tests utilizing timestamptz.