### PR TITLE
Automatic gob type registration

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -3,6 +3,7 @@ package scs
 import (
 	"bytes"
 	"encoding/gob"
+	"reflect"
 	"time"
 )
 
@@ -48,4 +49,22 @@ func (GobCodec) Decode(b []byte) (time.Time, map[string]interface{}, error) {
 	}
 
 	return aux.Deadline, aux.Values, nil
+}
+
+// RegisterType registers a type to be available for adding in session data and following encoding/decoding operations
+func (s *SessionManager) registerType(value interface{}) {
+	gob.Register(value)
+	rt := reflect.TypeOf(value).String()
+	s.gobTypes = append(s.gobTypes, rt)
+}
+
+// checkRegisteredType checks if type has been registered
+func (s *SessionManager) checkRegisteredType(value interface{}) bool {
+	rt := reflect.TypeOf(value).String()
+	for _, t := range s.gobTypes {
+		if rt == t {
+			return true
+		}
+	}
+	return false
 }

--- a/data.go
+++ b/data.go
@@ -159,8 +159,9 @@ func (s *SessionManager) Put(ctx context.Context, key string, val interface{}) {
 	if !s.checkRegisteredType(val) {
 		if s.AutoTypeRegistration {
 			s.registerType(val)
+		} else {
+			log.Panicf("scs: type %T is not registered\n", val)
 		}
-		log.Panicf("scs: type %T is not registered\n", val)
 	}
 
 	sd.mu.Lock()

--- a/data.go
+++ b/data.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -151,8 +152,16 @@ func (s *SessionManager) Destroy(ctx context.Context) error {
 // Put adds a key and corresponding value to the session data. Any existing
 // value for the key will be replaced. The session data status will be set to
 // Modified.
+// If data type to put in has not been registered yet - panics or registers that type, depending on AutoTypeResistration flag
 func (s *SessionManager) Put(ctx context.Context, key string, val interface{}) {
 	sd := s.getSessionDataFromContext(ctx)
+
+	if !s.checkRegisteredType(val) {
+		if s.AutoTypeRegistration {
+			s.registerType(val)
+		}
+		log.Panicf("scs: type %T is not registered\n", val)
+	}
 
 	sd.mu.Lock()
 	sd.values[key] = val

--- a/session.go
+++ b/session.go
@@ -48,6 +48,12 @@ type SessionManager struct {
 	// contextKey is the key used to set and retrieve the session data from a
 	// context.Context. It's automatically generated to ensure uniqueness.
 	contextKey contextKey
+
+	// gobTypes slice containts all types registered for encoding/decoding via golang gob package
+	gobTypes []string
+
+	// AutoTypeRegistration flag defines either use automatic gob types registration or not
+	AutoTypeRegistration bool
 }
 
 // SessionCookie contains the configuration settings for session cookies.
@@ -98,12 +104,14 @@ type SessionCookie struct {
 // concurrent use.
 func New() *SessionManager {
 	s := &SessionManager{
-		IdleTimeout: 0,
-		Lifetime:    24 * time.Hour,
-		Store:       memstore.New(),
-		Codec:       GobCodec{},
-		ErrorFunc:   defaultErrorFunc,
-		contextKey:  generateContextKey(),
+		IdleTimeout:          0,
+		Lifetime:             24 * time.Hour,
+		Store:                memstore.New(),
+		Codec:                GobCodec{},
+		ErrorFunc:            defaultErrorFunc,
+		contextKey:           generateContextKey(),
+		gobTypes:             make([]string, 0),
+		AutoTypeRegistration: true,
 		Cookie: SessionCookie{
 			Name:     "session",
 			Domain:   "",


### PR DESCRIPTION
Added automatic gob type registration possibility, that is enabled by default, but can be disabled by developer.
Upon Put a new value into session, it checks whether the type of value is registered and take appropriate action: panics, if auto registration is false, otherwise registers the type.