### PR TITLE
Automatic gob types registration feature

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -3,6 +3,7 @@ package scs
 import (
 	"bytes"
 	"encoding/gob"
+	"reflect"
 	"time"
 )
 
@@ -48,4 +49,22 @@ func (GobCodec) Decode(b []byte) (time.Time, map[string]interface{}, error) {
 	}
 
 	return aux.Deadline, aux.Values, nil
+}
+
+// RegisterType registers a type to be available for adding in session data and following encoding/decoding operations
+func (s *SessionManager) registerType(value interface{}) {
+	gob.Register(value)
+	rt := reflect.TypeOf(value).String()
+	s.gobTypes = append(s.gobTypes, rt)
+}
+
+// checkRegisteredType checks if type has been registered
+func (s *SessionManager) checkRegisteredType(value interface{}) bool {
+	rt := reflect.TypeOf(value).String()
+	for _, t := range s.gobTypes {
+		if rt == t {
+			return true
+		}
+	}
+	return false
 }

--- a/data.go
+++ b/data.go
@@ -159,8 +159,9 @@ func (s *SessionManager) Put(ctx context.Context, key string, val interface{}) {
 	if !s.checkRegisteredType(val) {
 		if s.AutoTypeRegistration {
 			s.registerType(val)
+		} else {
+			log.Panicf("scs: type %T is not registered\n", val)
 		}
-		log.Panicf("scs: type %T is not registered\n", val)
 	}
 
 	sd.mu.Lock()

--- a/data.go
+++ b/data.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -151,8 +152,16 @@ func (s *SessionManager) Destroy(ctx context.Context) error {
 // Put adds a key and corresponding value to the session data. Any existing
 // value for the key will be replaced. The session data status will be set to
 // Modified.
+// If data type to put in has not been registered yet - panics or registers that type, depending on AutoTypeResistration flag
 func (s *SessionManager) Put(ctx context.Context, key string, val interface{}) {
 	sd := s.getSessionDataFromContext(ctx)
+
+	if !s.checkRegisteredType(val) {
+		if s.AutoTypeRegistration {
+			s.registerType(val)
+		}
+		log.Panicf("scs: type %T is not registered\n", val)
+	}
 
 	sd.mu.Lock()
 	sd.values[key] = val

--- a/data.go
+++ b/data.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"log"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -152,16 +151,12 @@ func (s *SessionManager) Destroy(ctx context.Context) error {
 // Put adds a key and corresponding value to the session data. Any existing
 // value for the key will be replaced. The session data status will be set to
 // Modified.
-// If data type to put in has not been registered yet - panics or registers that type, depending on AutoTypeResistration flag
+// If AutoTypeRegistration is enabled and data type to put in has not been registered yet, registers the type
 func (s *SessionManager) Put(ctx context.Context, key string, val interface{}) {
 	sd := s.getSessionDataFromContext(ctx)
 
-	if !s.checkRegisteredType(val) {
-		if s.AutoTypeRegistration {
-			s.registerType(val)
-		} else {
-			log.Panicf("scs: type %T is not registered\n", val)
-		}
+	if s.AutoTypeRegistration && !s.checkRegisteredType(val) {
+		s.registerType(val)
 	}
 
 	sd.mu.Lock()

--- a/session.go
+++ b/session.go
@@ -48,6 +48,12 @@ type SessionManager struct {
 	// contextKey is the key used to set and retrieve the session data from a
 	// context.Context. It's automatically generated to ensure uniqueness.
 	contextKey contextKey
+
+	// gobTypes slice containts all types registered for encoding/decoding via golang gob package
+	gobTypes []string
+
+	// AutoTypeRegistration flag defines either use automatic gob types registration or not
+	AutoTypeRegistration bool
 }
 
 // SessionCookie contains the configuration settings for session cookies.
@@ -98,12 +104,14 @@ type SessionCookie struct {
 // concurrent use.
 func New() *SessionManager {
 	s := &SessionManager{
-		IdleTimeout: 0,
-		Lifetime:    24 * time.Hour,
-		Store:       memstore.New(),
-		Codec:       GobCodec{},
-		ErrorFunc:   defaultErrorFunc,
-		contextKey:  generateContextKey(),
+		IdleTimeout:          0,
+		Lifetime:             24 * time.Hour,
+		Store:                memstore.New(),
+		Codec:                GobCodec{},
+		ErrorFunc:            defaultErrorFunc,
+		contextKey:           generateContextKey(),
+		gobTypes:             make([]string, 0),
+		AutoTypeRegistration: true,
 		Cookie: SessionCookie{
 			Name:     "session",
 			Domain:   "",

--- a/session.go
+++ b/session.go
@@ -52,7 +52,7 @@ type SessionManager struct {
 	// gobTypes slice containts all types registered for encoding/decoding via golang gob package
 	gobTypes []string
 
-	// AutoTypeRegistration flag defines either use automatic gob types registration or not
+	// AutoTypeRegistration flag defines either use automatic gob types registration or not; false by default
 	AutoTypeRegistration bool
 }
 
@@ -111,7 +111,7 @@ func New() *SessionManager {
 		ErrorFunc:            defaultErrorFunc,
 		contextKey:           generateContextKey(),
 		gobTypes:             make([]string, 0),
-		AutoTypeRegistration: true,
+		AutoTypeRegistration: false,
 		Cookie: SessionCookie{
 			Name:     "session",
 			Domain:   "",


### PR DESCRIPTION
Added additional functionality to register types automatically for encoding/decoding, via gob package. Provide developers with a possibility to enable automatic gob types registration by changing SessionManager field AutoTypeRegistration to true (false by default). If enabled (true), upon each call to Put, it will checks whether a value type has been registered and added to SessionManager gobTypes string slice, otherwise gob.Resigter(value) will be called and the value type will be added to gobTypes slice. A bit of comfortability for simple tasks.