### PR TITLE
Add automatic types registration functionality for gob encoding

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -3,6 +3,7 @@ package scs
 import (
 	"bytes"
 	"encoding/gob"
+	"reflect"
 	"time"
 )
 
@@ -48,4 +49,22 @@ func (GobCodec) Decode(b []byte) (time.Time, map[string]interface{}, error) {
 	}
 
 	return aux.Deadline, aux.Values, nil
+}
+
+// RegisterType registers a type to be available for encoding/decoding operations and adds it to gobTypes slice
+func (s *SessionManager) registerType(value interface{}) {
+	gob.Register(value)
+	rt := reflect.TypeOf(value).String()
+	s.gobTypes = append(s.gobTypes, rt)
+}
+
+// checkRegisteredType checks if type has been registered
+func (s *SessionManager) checkRegisteredType(value interface{}) bool {
+	rt := reflect.TypeOf(value).String()
+	for _, t := range s.gobTypes {
+		if rt == t {
+			return true
+		}
+	}
+	return false
 }

--- a/data.go
+++ b/data.go
@@ -151,8 +151,15 @@ func (s *SessionManager) Destroy(ctx context.Context) error {
 // Put adds a key and corresponding value to the session data. Any existing
 // value for the key will be replaced. The session data status will be set to
 // Modified.
+// if AutoTypeRegister is true, also checks whether type has been registered and takes appropriate actions
 func (s *SessionManager) Put(ctx context.Context, key string, val interface{}) {
 	sd := s.getSessionDataFromContext(ctx)
+
+	if s.AutoTypeRegister {
+		if !s.checkRegisteredType(val) {
+			s.registerType(val)
+		}
+	}
 
 	sd.mu.Lock()
 	sd.values[key] = val

--- a/session.go
+++ b/session.go
@@ -48,6 +48,12 @@ type SessionManager struct {
 	// contextKey is the key used to set and retrieve the session data from a
 	// context.Context. It's automatically generated to ensure uniqueness.
 	contextKey contextKey
+
+	// AutoTypeRegister is a flag that defines whether auto type registering or not
+	AutoTypeRegister bool
+
+	// gobTypes contains a list of automatically registered types for gob encoding/decoding; used only if AutoTypeRgistered is true
+	gobTypes []string
 }
 
 // SessionCookie contains the configuration settings for session cookies.
@@ -98,12 +104,14 @@ type SessionCookie struct {
 // concurrent use.
 func New() *SessionManager {
 	s := &SessionManager{
-		IdleTimeout: 0,
-		Lifetime:    24 * time.Hour,
-		Store:       memstore.New(),
-		Codec:       GobCodec{},
-		ErrorFunc:   defaultErrorFunc,
-		contextKey:  generateContextKey(),
+		IdleTimeout:      0,
+		Lifetime:         24 * time.Hour,
+		Store:            memstore.New(),
+		Codec:            GobCodec{},
+		ErrorFunc:        defaultErrorFunc,
+		contextKey:       generateContextKey(),
+		AutoTypeRegister: false,
+		gobTypes:         make([]string, 0),
 		Cookie: SessionCookie{
 			Name:     "session",
 			Domain:   "",


### PR DESCRIPTION
Added additional functionality to register types automatically for encoding/decoding, via gob package. Provide developers with a possibility to enable automatic gob types registration by changing SessionManager field AutoTypeRegistration to true (false by default). If enabled (true), upon each call to Put, it will checks whether a value type has been registered and added to SessionManager gobTypes string slice, otherwise gob.Resigter(value) will be called and the value type will be added to gobTypes slice. A bit of comfortability for simple tasks.