### PR TITLE
Added an ability to change default table/column names for postgres store

### DIFF
--- a/postgresstore/README.md
+++ b/postgresstore/README.md
@@ -66,6 +66,19 @@ func getHandler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+## Custom table and column names
+
+In case you need custom names for the table or columns, you can use functional options:
+
+```go
+postgresstore.New(db,
+    postgresstore.WithSessionTableName("my_session_table"),
+    postgresstore.WithDataColumnName("my_data_column"),
+    postgresstore.WithTokenColumnName("my_token_column"),
+    postgresstore.WithExpiryColumnName("my_expiry_date_column"),
+)
+```
+
 ## Expired Session Cleanup
 
 This package provides a background 'cleanup' goroutine to delete expired session data. This stops the database table from holding on to invalid sessions indefinitely and growing unnecessarily large. By default the cleanup runs every 5 minutes. You can change this by using the `NewWithCleanupInterval()` function to initialize your session store. For example:

--- a/postgresstore/options.go
+++ b/postgresstore/options.go
@@ -1,0 +1,45 @@
+package postgresstore
+
+import (
+	"time"
+)
+
+type storeOptions struct {
+	sessionTableName string
+	dataColumnName   string
+	tokenColumnName  string
+	expiryColumnName string
+	cleanupInterval  time.Duration
+}
+
+type StoreOption func(*storeOptions)
+
+func WithSessionTableName(tableName string) StoreOption {
+	return func(options *storeOptions) {
+		options.sessionTableName = tableName
+	}
+}
+
+func WithDataColumnName(columnName string) StoreOption {
+	return func(options *storeOptions) {
+		options.dataColumnName = columnName
+	}
+}
+
+func WithTokenColumnName(columnName string) StoreOption {
+	return func(options *storeOptions) {
+		options.tokenColumnName = columnName
+	}
+}
+
+func WithExpiryColumnName(columnName string) StoreOption {
+	return func(options *storeOptions) {
+		options.expiryColumnName = columnName
+	}
+}
+
+func WithCleanupInterval(interval time.Duration) StoreOption {
+	return func(options *storeOptions) {
+		options.cleanupInterval = interval
+	}
+}


### PR DESCRIPTION
One would have an ability to change default names of the table and columns:

```
New(db,
  WithSessionTableName("schema.session_table"),
  WithExpiryColumnName("expiry_date"),
  WithTokenColumnName("token"),
)
```

See https://github.com/alexedwards/scs/issues/180#issuecomment-1855552131 for details