### PR TITLE
Add Opt-In Functionality for Hashed Session Token Storage

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -198,6 +198,50 @@ func TestSessionManager_Load(T *testing.T) {
 			t.Error("returned context is unexpectedly nil")
 		}
 	})
+
+	T.Run("with token hashing", func(t *testing.T) {
+		s := New()
+		s.HashTokenInStore = true
+		s.IdleTimeout = time.Hour * 24
+
+		expectedToken := "example"
+		expectedExpiry := time.Now().Add(time.Hour)
+
+		initialCtx := context.WithValue(context.Background(), s.contextKey, &sessionData{
+			deadline: expectedExpiry,
+			token:    expectedToken,
+			values: map[string]interface{}{
+				"blah": "blah",
+			},
+			mu: sync.Mutex{},
+		})
+
+		actualToken, actualExpiry, err := s.Commit(initialCtx)
+		if expectedToken != actualToken {
+			t.Errorf("expected token to equal %q, but received %q", expectedToken, actualToken)
+		}
+		if expectedExpiry != actualExpiry {
+			t.Errorf("expected expiry to equal %v, but received %v", expectedExpiry, actualExpiry)
+		}
+		if err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+
+		retrievedCtx, err := s.Load(context.Background(), expectedToken)
+		if err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+		retrievedSessionData, ok := retrievedCtx.Value(s.contextKey).(*sessionData)
+		if !ok {
+			t.Errorf("unexpected data in retrieved context")
+		} else if retrievedSessionData.token != expectedToken {
+			t.Errorf("expected token in context's session data data to equal %v, but received %v", expectedToken, retrievedSessionData.token)
+		}
+
+		if err := s.Destroy(retrievedCtx); err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+	})
 }
 
 func TestSessionManager_Commit(T *testing.T) {
@@ -346,52 +390,6 @@ func TestSessionManager_Commit(T *testing.T) {
 			t.Errorf("expected expiry to equal %v, but received %v", expectedExpiry, actualExpiry)
 		}
 		if err != nil {
-			t.Errorf("unexpected error returned: %v", err)
-		}
-	})
-}
-
-func TestTokenHashing(T *testing.T) {
-	T.Run("with token hashing", func(t *testing.T) {
-		s := New()
-		s.HashTokenInStore = true
-		s.IdleTimeout = time.Hour * 24
-
-		expectedToken := "example"
-		expectedExpiry := time.Now().Add(time.Hour)
-
-		initialCtx := context.WithValue(context.Background(), s.contextKey, &sessionData{
-			deadline: expectedExpiry,
-			token:    expectedToken,
-			values: map[string]interface{}{
-				"blah": "blah",
-			},
-			mu: sync.Mutex{},
-		})
-
-		actualToken, actualExpiry, err := s.Commit(initialCtx)
-		if expectedToken != actualToken {
-			t.Errorf("expected token to equal %q, but received %q", expectedToken, actualToken)
-		}
-		if expectedExpiry != actualExpiry {
-			t.Errorf("expected expiry to equal %v, but received %v", expectedExpiry, actualExpiry)
-		}
-		if err != nil {
-			t.Errorf("unexpected error returned: %v", err)
-		}
-
-		retrievedCtx, err := s.Load(context.Background(), expectedToken)
-		if err != nil {
-			t.Errorf("unexpected error returned: %v", err)
-		}
-		retrievedSessionData, ok := retrievedCtx.Value(s.contextKey).(*sessionData)
-		if !ok {
-			t.Errorf("unexpected data in retrieved context")
-		} else if retrievedSessionData.token != expectedToken {
-			t.Errorf("expected token in context's session data data to equal %v, but received %v", expectedToken, retrievedSessionData.token)
-		}
-
-		if err := s.Destroy(retrievedCtx); err != nil {
 			t.Errorf("unexpected error returned: %v", err)
 		}
 	})

--- a/data_test.go
+++ b/data_test.go
@@ -320,6 +320,81 @@ func TestSessionManager_Commit(T *testing.T) {
 			t.Error("expected error not returned")
 		}
 	})
+
+	T.Run("with token hashing", func(t *testing.T) {
+		s := New()
+		s.HashTokenInStore = true
+		s.IdleTimeout = time.Hour * 24
+
+		expectedToken := "example"
+		expectedExpiry := time.Now().Add(time.Hour)
+
+		ctx := context.WithValue(context.Background(), s.contextKey, &sessionData{
+			deadline: expectedExpiry,
+			token:    expectedToken,
+			values: map[string]interface{}{
+				"blah": "blah",
+			},
+			mu: sync.Mutex{},
+		})
+
+		actualToken, actualExpiry, err := s.Commit(ctx)
+		if expectedToken != actualToken {
+			t.Errorf("expected token to equal %q, but received %q", expectedToken, actualToken)
+		}
+		if expectedExpiry != actualExpiry {
+			t.Errorf("expected expiry to equal %v, but received %v", expectedExpiry, actualExpiry)
+		}
+		if err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+	})
+}
+
+func TestTokenHashing(T *testing.T) {
+	T.Run("with token hashing", func(t *testing.T) {
+		s := New()
+		s.HashTokenInStore = true
+		s.IdleTimeout = time.Hour * 24
+
+		expectedToken := "example"
+		expectedExpiry := time.Now().Add(time.Hour)
+
+		initialCtx := context.WithValue(context.Background(), s.contextKey, &sessionData{
+			deadline: expectedExpiry,
+			token:    expectedToken,
+			values: map[string]interface{}{
+				"blah": "blah",
+			},
+			mu: sync.Mutex{},
+		})
+
+		actualToken, actualExpiry, err := s.Commit(initialCtx)
+		if expectedToken != actualToken {
+			t.Errorf("expected token to equal %q, but received %q", expectedToken, actualToken)
+		}
+		if expectedExpiry != actualExpiry {
+			t.Errorf("expected expiry to equal %v, but received %v", expectedExpiry, actualExpiry)
+		}
+		if err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+
+		retrievedCtx, err := s.Load(context.Background(), expectedToken)
+		if err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+		retrievedSessionData, ok := retrievedCtx.Value(s.contextKey).(*sessionData)
+		if !ok {
+			t.Errorf("unexpected data in retrieved context")
+		} else if retrievedSessionData.token != expectedToken {
+			t.Errorf("expected token in context's session data data to equal %v, but received %v", expectedToken, retrievedSessionData.token)
+		}
+
+		if err := s.Destroy(retrievedCtx); err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+	})
 }
 
 func TestPut(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -45,6 +45,9 @@ type SessionManager struct {
 	// a function which logs the error and returns a customized HTML error page.
 	ErrorFunc func(http.ResponseWriter, *http.Request, error)
 
+	// HashTokenInStore controls whether or not to store the session token or a hashed version in the store.
+	HashTokenInStore bool
+
 	// contextKey is the key used to set and retrieve the session data from a
 	// context.Context. It's automatically generated to ensure uniqueness.
 	contextKey contextKey


### PR DESCRIPTION
## Summary
This PR introduces an opt-in feature that allows storing session tokens as hashes in the storage system. The goal of this update is to enhance security measures by ensuring that session tokens, which are sensitive in nature, are stored in a hashed format (SHA256). This mitigates risks associated with the exposure of raw tokens. Alongside the core functionality, tests have been added to validate the implementation and ensure its reliability.

## Changes
The `SessionManager` is extended to accept a boolean value for the new `HashTokenInStore` field.
- Default - `HashTokenInStore == false`: The behavior from before this PR is used. I.e. session tokens will not be hashed before getting saved in the store
- `HashTokenInStore == true`: Session tokens will be hashed before being saved to the store. Subsequent lookups (whether it be finds, deletes...) will first hash the provided token before using the hashed value in the lookup.

This PR should not bring any breaking changes as it defaults to the old behavior. Rather, it extends functionality by providing extra opt-in security features.