### PR TITLE
Add a warning that iterating all sessions with redis can be very slow.

### DIFF
--- a/goredisstore/README.md
+++ b/goredisstore/README.md
@@ -79,3 +79,9 @@ sessionManagerOne.Store = goredisstore.NewWithPrefix(client, "scs:session:1:")
 sessionManagerTwo = scs.New()
 sessionManagerTwo.Store = goredisstore.NewWithPrefix(client, "scs:session:2:")
 ```
+## Iterating over all Sessions
+
+If you intend to use the sessionstore.Iterate() function to iterate over all
+sessions on a busy Redis server with many keys stored, be warned that this
+can take a long time and is therefore probably only interesting for debugging
+purposes.

--- a/redisstore/README.md
+++ b/redisstore/README.md
@@ -80,3 +80,10 @@ sessionManagerOne.Store = redisstore.NewWithPrefix(pool, "scs:session:1:")
 sessionManagerTwo = scs.New()
 sessionManagerTwo.Store = redisstore.NewWithPrefix(pool, "scs:session:2:")
 ```
+
+## Iterating over all Sessions
+
+If you intend to use the sessionstore.Iterate() function to iterate over all
+sessions on a busy Redis server with many keys stored, be warned that this
+can take a long time and is therefore probably only interesting for debugging
+purposes.


### PR DESCRIPTION
I just did debug a problem that using Redis in a code path for an oauth2 flow was very slow compared to the version with the session store in a database. The problem turned out to be debugging code that used sessionstore.Iterate() to dump out all sessions which can be excruciatingly slow on a busy Redis server. In my case it took more than 10s to iterate through all sessions. So I thought it might be a good idea to warn that this might not be a good idea.
