### PR TITLE
Implement http.Hijacker for sessionResponseWriter for go1.18

### DIFF
--- a/session_go118.go
+++ b/session_go118.go
@@ -1,0 +1,14 @@
+//go:build go1.18
+// +build go1.18
+
+package scs
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+)
+
+func (sw *sessionResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return sw.ResponseWriter.(http.Hijacker).Hijack()
+}

--- a/session_go118_test.go
+++ b/session_go118_test.go
@@ -1,0 +1,36 @@
+//go:build go1.18
+// +build go1.18
+
+package scs
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestHijacker(t *testing.T) {
+	t.Parallel()
+
+	sessionManager := New()
+	sessionManager.Lifetime = 500 * time.Millisecond
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/get", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, ok := w.(http.Hijacker)
+
+		fmt.Fprint(w, ok)
+	}))
+
+	ts := newTestServer(t, sessionManager.LoadAndSave(mux))
+	defer ts.Close()
+
+	ts.execute(t, "/put")
+
+	_, body := ts.execute(t, "/get")
+	if body != "true" {
+		t.Errorf("want %q; got %q", "true", body)
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/alexedwards/scs/issues/188 for go1.18