### PR TITLE
feat: add tableName config for all table based stores

### DIFF
--- a/cockroachdbstore/cockroachdbstore.go
+++ b/cockroachdbstore/cockroachdbstore.go
@@ -2,20 +2,32 @@ package cockroachdbstore
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"time"
 )
+
+type Config struct {
+	// CleanUpInterval is the interval between each cleanup operation.
+	// If set to 0, the cleanup operation is disabled.
+	CleanUpInterval time.Duration
+
+	// TableName is the name of the table where the session data will be stored.
+	// If not set, it will default to "sessions".
+	TableName string
+}
 
 // CockroachDBStore represents the session store.
 type CockroachDBStore struct {
 	db          *sql.DB
 	stopCleanup chan bool
+	tableName   string
 }
 
 // New returns a new CockroachDBStore instance, with a background cleanup goroutine
 // that runs every 5 minutes to remove expired session data.
 func New(db *sql.DB) *CockroachDBStore {
-	return NewWithCleanupInterval(db, 5*time.Minute)
+	return NewWithConfig(db, Config{CleanUpInterval: 5 * time.Minute})
 }
 
 // NewWithCleanupInterval returns a new CockroachDBStore instance. The cleanupInterval
@@ -23,18 +35,35 @@ func New(db *sql.DB) *CockroachDBStore {
 // background cleanup goroutine. Setting it to 0 prevents the cleanup goroutine
 // from running (i.e. expired sessions will not be removed).
 func NewWithCleanupInterval(db *sql.DB, cleanupInterval time.Duration) *CockroachDBStore {
-	p := &CockroachDBStore{db: db}
-	if cleanupInterval > 0 {
-		go p.startCleanup(cleanupInterval)
+	return NewWithConfig(db, Config{CleanUpInterval: cleanupInterval})
+}
+
+// NewWithConfig returns a new CockroachDBStore instance using the provided config.
+// If the TableName field is empty, it will be set to "sessions".
+// If the CleanUpInterval field is 0, the cleanup goroutine will not be started.
+func NewWithConfig(db *sql.DB, config Config) *CockroachDBStore {
+	if config.TableName == "" {
+		config.TableName = "sessions"
 	}
-	return p
+
+	store := &CockroachDBStore{
+		db:        db,
+		tableName: config.TableName,
+	}
+
+	if config.CleanUpInterval > 0 {
+		go store.startCleanup(config.CleanUpInterval)
+	}
+
+	return store
 }
 
 // Find returns the data for a given session token from the CockroachDBStore instance.
 // If the session token is not found or is expired, the returned exists flag will
 // be set to false.
 func (p *CockroachDBStore) Find(token string) (b []byte, exists bool, err error) {
-	row := p.db.QueryRow("SELECT data FROM sessions WHERE token = $1 AND current_timestamp < expiry", token)
+	query := fmt.Sprintf("SELECT data FROM %s WHERE token = $1 AND current_timestamp < expiry", p.tableName)
+	row := p.db.QueryRow(query, token)
 	err = row.Scan(&b)
 	if err == sql.ErrNoRows {
 		return nil, false, nil
@@ -48,24 +77,24 @@ func (p *CockroachDBStore) Find(token string) (b []byte, exists bool, err error)
 // given expiry time. If the session token already exists, then the data and expiry
 // time are updated.
 func (p *CockroachDBStore) Commit(token string, b []byte, expiry time.Time) error {
-	_, err := p.db.Exec("INSERT INTO sessions (token, data, expiry) VALUES ($1, $2, $3) ON CONFLICT (token) DO UPDATE SET data = EXCLUDED.data, expiry = EXCLUDED.expiry", token, b, expiry)
-	if err != nil {
-		return err
-	}
-	return nil
+	query := fmt.Sprintf("INSERT INTO %s (token, data, expiry) VALUES ($1, $2, $3) ON CONFLICT (token) DO UPDATE SET data = EXCLUDED.data, expiry = EXCLUDED.expiry", p.tableName)
+	_, err := p.db.Exec(query, token, b, expiry)
+	return err
 }
 
 // Delete removes a session token and corresponding data from the CockroachDBStore
 // instance.
 func (p *CockroachDBStore) Delete(token string) error {
-	_, err := p.db.Exec("DELETE FROM sessions WHERE token = $1", token)
+	query := fmt.Sprintf("DELETE FROM %s WHERE token = $1", p.tableName)
+	_, err := p.db.Exec(query, token)
 	return err
 }
 
 // All returns a map containing the token and data for all active (i.e.
 // not expired) sessions in the CockroachDBStore instance.
 func (p *CockroachDBStore) All() (map[string][]byte, error) {
-	rows, err := p.db.Query("SELECT token, data FROM sessions WHERE current_timestamp < expiry")
+	query := fmt.Sprintf("SELECT token, data FROM %s WHERE current_timestamp < expiry", p.tableName)
+	rows, err := p.db.Query(query)
 	if err != nil {
 		return nil, err
 	}
@@ -129,6 +158,7 @@ func (p *CockroachDBStore) StopCleanup() {
 }
 
 func (p *CockroachDBStore) deleteExpired() error {
-	_, err := p.db.Exec("DELETE FROM sessions WHERE expiry < current_timestamp")
+	query := fmt.Sprintf("DELETE FROM %s WHERE expiry < current_timestamp", p.tableName)
+	_, err := p.db.Exec(query)
 	return err
 }

--- a/postgresstore/postgresstore.go
+++ b/postgresstore/postgresstore.go
@@ -2,20 +2,32 @@ package postgresstore
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"time"
 )
+
+type Config struct {
+	// CleanUpInterval is the interval between each cleanup operation.
+	// If set to 0, the cleanup operation is disabled.
+	CleanUpInterval time.Duration
+
+	// TableName is the name of the table where the session data will be stored.
+	// If not set, it will default to "sessions".
+	TableName string
+}
 
 // PostgresStore represents the session store.
 type PostgresStore struct {
 	db          *sql.DB
 	stopCleanup chan bool
+	tableName   string
 }
 
 // New returns a new PostgresStore instance, with a background cleanup goroutine
 // that runs every 5 minutes to remove expired session data.
 func New(db *sql.DB) *PostgresStore {
-	return NewWithCleanupInterval(db, 5*time.Minute)
+	return NewWithConfig(db, Config{CleanUpInterval: 5 * time.Minute, TableName: "sessions"})
 }
 
 // NewWithCleanupInterval returns a new PostgresStore instance. The cleanupInterval
@@ -23,18 +35,37 @@ func New(db *sql.DB) *PostgresStore {
 // background cleanup goroutine. Setting it to 0 prevents the cleanup goroutine
 // from running (i.e. expired sessions will not be removed).
 func NewWithCleanupInterval(db *sql.DB, cleanupInterval time.Duration) *PostgresStore {
-	p := &PostgresStore{db: db}
-	if cleanupInterval > 0 {
-		go p.startCleanup(cleanupInterval)
+	return NewWithConfig(db, Config{CleanUpInterval: cleanupInterval, TableName: "sessions"})
+}
+
+// NewWithConfig returns a new PostgresStore instance using the provided config.
+// If the TableName field is empty, it will be set to "sessions".
+// If the CleanUpInterval field is 0, the cleanup goroutine will not be started.
+func NewWithConfig(db *sql.DB, config Config) *PostgresStore {
+	if config.TableName == "" {
+		config.TableName = "sessions"
 	}
-	return p
+
+	store := &PostgresStore{
+		db:        db,
+		tableName: config.TableName,
+	}
+
+	if config.CleanUpInterval > 0 {
+		go store.startCleanup(config.CleanUpInterval)
+	}
+
+	return store
 }
 
 // Find returns the data for a given session token from the PostgresStore instance.
 // If the session token is not found or is expired, the returned exists flag will
 // be set to false.
 func (p *PostgresStore) Find(token string) (b []byte, exists bool, err error) {
-	row := p.db.QueryRow("SELECT data FROM sessions WHERE token = $1 AND current_timestamp < expiry", token)
+	row := p.db.QueryRow(
+		fmt.Sprintf("SELECT data FROM %s WHERE token = $1 AND current_timestamp < expiry", p.tableName),
+		token,
+	)
 	err = row.Scan(&b)
 	if err == sql.ErrNoRows {
 		return nil, false, nil
@@ -48,24 +79,30 @@ func (p *PostgresStore) Find(token string) (b []byte, exists bool, err error) {
 // given expiry time. If the session token already exists, then the data and expiry
 // time are updated.
 func (p *PostgresStore) Commit(token string, b []byte, expiry time.Time) error {
-	_, err := p.db.Exec("INSERT INTO sessions (token, data, expiry) VALUES ($1, $2, $3) ON CONFLICT (token) DO UPDATE SET data = EXCLUDED.data, expiry = EXCLUDED.expiry", token, b, expiry)
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err := p.db.Exec(
+		fmt.Sprintf("INSERT INTO %s (token, data, expiry) VALUES ($1, $2, $3) ON CONFLICT (token) DO UPDATE SET data = EXCLUDED.data, expiry = EXCLUDED.expiry", p.tableName),
+		token,
+		b,
+		expiry,
+	)
+	return err
 }
 
 // Delete removes a session token and corresponding data from the PostgresStore
 // instance.
 func (p *PostgresStore) Delete(token string) error {
-	_, err := p.db.Exec("DELETE FROM sessions WHERE token = $1", token)
+	_, err := p.db.Exec(fmt.Sprintf(
+		"DELETE FROM %s WHERE token = $1",
+		p.tableName),
+		token,
+	)
 	return err
 }
 
 // All returns a map containing the token and data for all active (i.e.
 // not expired) sessions in the PostgresStore instance.
 func (p *PostgresStore) All() (map[string][]byte, error) {
-	rows, err := p.db.Query("SELECT token, data FROM sessions WHERE current_timestamp < expiry")
+	rows, err := p.db.Query(fmt.Sprintf("SELECT token, data FROM %s WHERE current_timestamp < expiry", p.tableName))
 	if err != nil {
 		return nil, err
 	}
@@ -129,6 +166,6 @@ func (p *PostgresStore) StopCleanup() {
 }
 
 func (p *PostgresStore) deleteExpired() error {
-	_, err := p.db.Exec("DELETE FROM sessions WHERE expiry < current_timestamp")
+	_, err := p.db.Exec(fmt.Sprintf("DELETE FROM %s WHERE expiry < current_timestamp", p.tableName))
 	return err
 }


### PR DESCRIPTION
As per #180
I have added a `Config `type for all table based stores and MongoDB to configure the table name.
Tests are still missing, but I don't have a full testing setup ready for all stores.
Maybe someone else could provide a testing setup, like a compose file for me.

Please let me know if this is what you inteded the interface to look like.

