### PR TITLE
Always respect the provided session token in Load()

### DIFF
--- a/data.go
+++ b/data.go
@@ -64,7 +64,9 @@ func (s *SessionManager) Load(ctx context.Context, token string) (context.Contex
 	if err != nil {
 		return nil, err
 	} else if !found {
-		return s.addSessionDataToContext(ctx, newSessionData(s.Lifetime)), nil
+		sd := newSessionData(s.Lifetime)
+		sd.token = token
+		return s.addSessionDataToContext(ctx, sd), nil
 	}
 
 	sd := &sessionData{


### PR DESCRIPTION
This PR fixes an issue in `Load()` where the the provided session `token` is not stored in the `sessionData` if the session state wasn't found in the store. With this change, the `token` is always used, if provided by the user.

This is important because it allows the user to take full control over the session tokens used. In my use case, I have incoming M2M requests from other systems and CLIs that cannot easily support cookie jars in the client but rather identify the request with JWT bearer tokens. I then derive session IDs from these tokens to store the session state on the server between the requests.