### PR TITLE
feat: transfer idle timeout to session data level #235

### DIFF
--- a/data.go
+++ b/data.go
@@ -103,12 +103,20 @@ func (s *SessionManager) Load(ctx context.Context, token string) (context.Contex
 	// By default, set the expiry time to the deadline.
 	sd.expiry = sd.deadline
 
+	// A per-session idleTimeout can be set using [SessionManager.SetIdleTimeout].
+	// A value of 0 disables the idle timeout for this session regardless of
+	// the global setting.
+	idleTimeout := s.IdleTimeout
+	if timeout, ok := sd.values["__idleTimeout"].(int64); ok {
+		idleTimeout = time.Duration(timeout)
+	}
+
 	// If an idle timeout is being used, set the expiry to whichever comes first
 	// between the session deadline and idleTimeout expiry. We also set the status
 	// to Modified, which will force the session data to be re-committed to the
 	// session store with the updated new expiry time.
-	if s.IdleTimeout > 0 {
-		idleExpiry := time.Now().Add(s.IdleTimeout).UTC()
+	if idleTimeout > 0 {
+		idleExpiry := time.Now().Add(idleTimeout).UTC()
 
 		sd.expiry = minTime(sd.deadline, idleExpiry)
 		sd.status = Modified
@@ -138,6 +146,18 @@ func (s *SessionManager) Commit(ctx context.Context) (string, time.Time, error) 
 	b, err := s.Codec.Encode(sd.deadline, sd.values)
 	if err != nil {
 		return "", time.Time{}, err
+	}
+
+	idleTimeout := s.IdleTimeout
+	if timeout, ok := sd.values["__idleTimeout"].(int64); ok {
+		idleTimeout = time.Duration(timeout)
+	}
+
+	if idleTimeout > 0 {
+		idleExpiry := time.Now().Add(idleTimeout).UTC()
+		sd.expiry = minTime(sd.deadline, idleExpiry)
+	} else {
+		sd.expiry = sd.deadline
 	}
 
 	if err := s.doStoreCommit(ctx, sd.token, b, sd.expiry); err != nil {
@@ -565,6 +585,13 @@ func (s *SessionManager) PopTime(ctx context.Context, key string) time.Time {
 // you are using the standard LoadAndSave() middleware.
 func (s *SessionManager) RememberMe(ctx context.Context, val bool) {
 	s.Put(ctx, "__rememberMe", val)
+}
+
+// SetIdleTimeout sets the idle timeout for this specific session, overriding
+// the global IdleTimeout setting. A value of 0 disables the idle timeout for
+// this session regardless of the global setting.
+func (s *SessionManager) SetIdleTimeout(ctx context.Context, t time.Duration) {
+	s.Put(ctx, "__idleTimeout", int64(t))
 }
 
 // Iterate retrieves all active (i.e. not expired) sessions from the store and

--- a/session.go
+++ b/session.go
@@ -227,7 +227,9 @@ func (s *SessionManager) AddSessionCookie(ctx context.Context, w http.ResponseWr
 	if expiry.IsZero() {
 		cookie.Expires = time.Unix(1, 0)
 		cookie.MaxAge = -1
-	} else if s.Cookie.Persist || s.GetBool(ctx, "__rememberMe") {
+	} else if s.Cookie.Persist ||
+		s.GetBool(ctx, "__rememberMe") ||
+		s.GetInt64(ctx, "__idleTimeout") > 0 {
 		cookie.Expires = time.Unix(expiry.Unix()+1, 0)        // Round up to the nearest second.
 		cookie.MaxAge = int(time.Until(expiry).Seconds() + 1) // Round up to the nearest second.
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -56,6 +56,17 @@ func extractTokenFromCookie(c string) string {
 	return strings.SplitN(parts[0], "=", 2)[1]
 }
 
+func extractMaxAge(cookie string) int {
+	for _, part := range strings.Split(cookie, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "Max-Age=") {
+			v, _ := strconv.Atoi(strings.TrimPrefix(part, "Max-Age="))
+			return v
+		}
+	}
+	return -1
+}
+
 func TestEnable(t *testing.T) {
 	t.Parallel()
 
@@ -304,6 +315,121 @@ func TestRememberMe(t *testing.T) {
 	if strings.Contains(header.Get("Set-Cookie"), "Max-Age=") || strings.Contains(header.Get("Set-Cookie"), "Expires=") {
 		t.Errorf("want no Max-Age or Expires attributes; got %q", header.Get("Set-Cookie"))
 	}
+}
+
+func TestSetIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("overrides global idle timeout", func(t *testing.T) {
+		t.Parallel()
+
+		sessionManager := New()
+		sessionManager.IdleTimeout = 1 * time.Hour
+		sessionManager.Cookie.Persist = false
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/put", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sessionManager.Put(r.Context(), "foo", "bar")
+			sessionManager.SetIdleTimeout(r.Context(), 200*time.Millisecond)
+		}))
+		mux.HandleFunc("/get", func(w http.ResponseWriter, r *http.Request) {
+			v := sessionManager.Get(r.Context(), "foo")
+			if v == nil {
+				fmt.Fprintf(w, "foo does not exist in session")
+				return
+			}
+			fmt.Fprint(w, v.(string))
+		})
+
+		ts := newTestServer(t, sessionManager.LoadAndSave(mux))
+		defer ts.Close()
+
+		header, _ := ts.execute(t, "/put")
+		if !strings.Contains(header.Get("Set-Cookie"), "Max-Age=") || !strings.Contains(header.Get("Set-Cookie"), "Expires=") {
+			t.Errorf("want Max-Age and Expires attributes; got %q", header.Get("Set-Cookie"))
+		}
+
+		header, _ = ts.execute(t, "/put")
+		maxAge := extractMaxAge(header.Get("Set-Cookie"))
+		if maxAge > 1 {
+			t.Errorf("want Max-Age <= 1 (per-session bounds cookie, not global 1h); got %d", maxAge)
+		}
+
+		time.Sleep(250 * time.Millisecond)
+		_, body := ts.execute(t, "/get")
+		if body != "foo does not exist in session" {
+			t.Errorf("want %q; got %q", "foo does not exist in session", body)
+		}
+	})
+
+	t.Run("zero disables idle timeout for session", func(t *testing.T) {
+		t.Parallel()
+
+		sessionManager := New()
+		sessionManager.IdleTimeout = 100 * time.Millisecond
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/put", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sessionManager.Put(r.Context(), "foo", "bar")
+			sessionManager.SetIdleTimeout(r.Context(), 0)
+		}))
+		mux.HandleFunc("/get", func(w http.ResponseWriter, r *http.Request) {
+			v := sessionManager.Get(r.Context(), "foo")
+			if v == nil {
+				fmt.Fprintf(w, "foo does not exist in session")
+				return
+			}
+			fmt.Fprint(w, v.(string))
+		})
+
+		ts := newTestServer(t, sessionManager.LoadAndSave(mux))
+		defer ts.Close()
+
+		ts.execute(t, "/put")
+
+		time.Sleep(150 * time.Millisecond)
+		_, body := ts.execute(t, "/get")
+		if body != "bar" {
+			t.Errorf("want session alive (idle timeout disabled); got %q", body)
+		}
+	})
+
+	t.Run("remove reverts to global idle timeout", func(t *testing.T) {
+		t.Parallel()
+
+		sessionManager := New()
+		sessionManager.IdleTimeout = 200 * time.Millisecond
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/put", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sessionManager.Put(r.Context(), "foo", "bar")
+			sessionManager.SetIdleTimeout(r.Context(), 1*time.Hour)
+		}))
+		mux.HandleFunc("/remove-idle-timeout", func(w http.ResponseWriter, r *http.Request) {
+			sessionManager.Remove(r.Context(), "__idleTimeout")
+		})
+		mux.HandleFunc("/get", func(w http.ResponseWriter, r *http.Request) {
+			v := sessionManager.Get(r.Context(), "foo")
+			if v == nil {
+				fmt.Fprintf(w, "foo does not exist in session")
+				return
+			}
+			fmt.Fprint(w, v.(string))
+		})
+
+		ts := newTestServer(t, sessionManager.LoadAndSave(mux))
+		defer ts.Close()
+
+		ts.execute(t, "/put")
+		ts.execute(t, "/remove-idle-timeout")
+
+		// Global idle timeout (200ms) now applies; session should expire after 250ms.
+		time.Sleep(250 * time.Millisecond)
+		_, body := ts.execute(t, "/get")
+		if body != "foo does not exist in session" {
+			t.Errorf("want session expired (reverted to global 200ms); got %q", body)
+		}
+	})
 }
 
 func TestIterate(t *testing.T) {


### PR DESCRIPTION
These changes allow to set per-session idle timeouts which can overwrite the global idle timeout. This can be used to set different idle timeouts for different users.

Closes #235 