### PR TITLE
gormstore: export Session for callers using custom migration tooling

### DIFF
--- a/gormstore/gormstore.go
+++ b/gormstore/gormstore.go
@@ -13,15 +13,22 @@ type GORMStore struct {
 	stopCleanup chan bool
 }
 
-type session struct {
+// Session is the GORM model that GORMStore persists session records as.
+// It's exported so callers can plug it into their own migration tooling
+// (e.g. atlas, goose, plain SQL generators) instead of relying on
+// AutoMigrate. The field tags drive the same schema either way.
+type Session struct {
 	Token  string    `gorm:"column:token;primaryKey;type:varchar(43)"`
 	Data   []byte    `gorm:"column:data"`
 	Expiry time.Time `gorm:"column:expiry;index"`
 }
 
-func (session) TableName() string {
+func (Session) TableName() string {
 	return "sessions"
 }
+
+// session keeps existing internal call sites compiling without churn.
+type session = Session
 
 // New returns a new GORMStore instance, with a background cleanup goroutine
 // that runs every 5 minutes to remove expired session data.


### PR DESCRIPTION
Closes #254.

The session record GORMStore persists is unexported, so anyone using their own migration tooling (atlas, goose, hand-rolled SQL generators) either has to reimplement the gorm model from the field tags or fall back to \`AutoMigrate\`.

Promote it to \`Session\` with the same gorm tags so external migration tooling can plug it in directly. Internal call sites keep working via an unexported \`type session = Session\` alias.