### PR TITLE
Add opt-in recovery from session decode errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ Individual data items can be deleted from the session using the [`Remove()`](htt
 
 Behind the scenes SCS uses gob encoding to store session data, so if you want to store custom types in the session data they must be [registered](https://golang.org/pkg/encoding/gob/#Register) with the encoding/gob package first. Struct fields of custom types must also be exported so that they are visible to the encoding/gob package. Please [see here](https://gist.github.com/alexedwards/d6eca7136f98ec12ad606e774d3abad3) for a working example.
 
+By default, SCS returns an error if stored session data cannot be decoded. Because the client continues to send the same session token, the error will recur on every request until the session expires or the client removes its cookie. You can optionally recover from incompatible sessions by setting `DecodeErrorFunc`. Returning nil from the callback opts in to recovery: SCS deletes the invalid session and continues the request with an empty session. The callback also provides an opportunity to log the otherwise hidden decode error or record it in your application's telemetry:
+
+```go
+sessionManager.DecodeErrorFunc = func(ctx context.Context, err error) error {
+	log.Printf("discarding undecodable session: %v", err)
+	return nil
+}
+```
+
+When using the `LoadAndSave()` middleware, the invalid cookie will be removed. If the session is subsequently modified, a fresh token will be committed. Returning an error from `DecodeErrorFunc` aborts recovery and causes `Load()` to return that error, allowing the original decode error to be wrapped or replaced. Data from an incompatible session cannot be recovered, so users may need to authenticate again if authentication state was stored in it.
+
 ### Loading and Saving Sessions
 
 Most applications will use the [`LoadAndSave()`](https://pkg.go.dev/github.com/alexedwards/scs/v2#SessionManager.LoadAndSave) middleware. This middleware takes care of loading and committing session data to the session store, and communicating the session token to/from the client in a cookie as necessary.

--- a/data.go
+++ b/data.go
@@ -97,7 +97,24 @@ func (s *SessionManager) Load(ctx context.Context, token string) (context.Contex
 
 	sd.deadline, sd.values, err = s.Codec.Decode(b)
 	if err != nil {
-		return nil, err
+		if s.DecodeErrorFunc == nil {
+			return nil, err
+		}
+
+		if callbackErr := s.DecodeErrorFunc(ctx, err); callbackErr != nil {
+			return nil, callbackErr
+		}
+
+		if err := s.doStoreDelete(ctx, token); err != nil {
+			return nil, err
+		}
+
+		// Mark the replacement session as destroyed so LoadAndSave removes the
+		// invalid cookie. If the session is modified later in the request, Put will
+		// mark it as modified and Commit will generate a new token instead.
+		sd = newSessionData(s.Lifetime, s.IdleTimeout)
+		sd.status = Destroyed
+		return s.addSessionDataToContext(ctx, sd), nil
 	}
 
 	// By default, set the expiry time to the deadline.

--- a/data_test.go
+++ b/data_test.go
@@ -197,6 +197,110 @@ func TestSessionManager_Load(T *testing.T) {
 		if newCtx != nil {
 			t.Error("returned context is unexpectedly nil")
 		}
+		if _, found, err := s.Store.Find(expected); err != nil {
+			t.Errorf("error finding undecodable session: %v", err)
+		} else if !found {
+			t.Error("undecodable session was unexpectedly deleted from the store")
+		}
+	})
+
+	T.Run("with decode error callback", func(t *testing.T) {
+		s := New()
+		s.Lifetime = time.Hour
+		s.IdleTimeout = 10 * time.Minute
+
+		ctx := context.Background()
+		token := "example"
+		exampleDeadline := time.Now().Add(time.Hour)
+		var decodeErr error
+
+		if err := s.Store.Commit(token, []byte(""), exampleDeadline); err != nil {
+			t.Errorf("error committing to session store: %v", err)
+		}
+
+		s.DecodeErrorFunc = func(ctx context.Context, err error) error {
+			decodeErr = err
+			return nil
+		}
+
+		before := time.Now()
+		newCtx, err := s.Load(ctx, token)
+		after := time.Now()
+		if err != nil {
+			t.Errorf("unexpected error loading from session manager: %v", err)
+		}
+		if newCtx == nil {
+			t.Fatal("returned context is unexpectedly nil")
+		}
+		if decodeErr == nil {
+			t.Error("decode error was not passed to callback")
+		}
+		if status := s.Status(newCtx); status != Destroyed {
+			t.Errorf("expected session status %v; got %v", Destroyed, status)
+		}
+		if actualToken := s.Token(newCtx); actualToken != "" {
+			t.Errorf("expected empty replacement token; got %q", actualToken)
+		}
+		deadline := s.Deadline(newCtx)
+		if deadline.Before(before.Add(s.Lifetime)) || deadline.After(after.Add(s.Lifetime)) {
+			t.Errorf("replacement deadline %v was not set using lifetime %v", deadline, s.Lifetime)
+		}
+		expiry := s.Expiry(newCtx)
+		if expiry.Before(before.Add(s.IdleTimeout)) || expiry.After(after.Add(s.IdleTimeout)) {
+			t.Errorf("replacement expiry %v was not set using idle timeout %v", expiry, s.IdleTimeout)
+		}
+		if _, found, err := s.Store.Find(token); err != nil {
+			t.Errorf("error finding invalid session: %v", err)
+		} else if found {
+			t.Error("invalid session was not deleted from the store")
+		}
+	})
+
+	T.Run("with error deleting after decode error callback", func(t *testing.T) {
+		s := New()
+		store := &mockstore.MockStore{}
+
+		ctx := context.Background()
+		token := "example"
+		expectedErr := errors.New("arbitrary")
+
+		store.ExpectFind(token, []byte(""), true, nil)
+		store.ExpectDelete(token, expectedErr)
+		s.Store = store
+		s.DecodeErrorFunc = func(context.Context, error) error {
+			return nil
+		}
+
+		newCtx, err := s.Load(ctx, token)
+		if err != expectedErr {
+			t.Errorf("expected error %v; got %v", expectedErr, err)
+		}
+		if newCtx != nil {
+			t.Error("returned context is unexpectedly not nil")
+		}
+	})
+
+	T.Run("with error returned by decode error callback", func(t *testing.T) {
+		s := New()
+		store := &mockstore.MockStore{}
+
+		ctx := context.Background()
+		token := "example"
+		expectedErr := errors.New("arbitrary")
+
+		store.ExpectFind(token, []byte(""), true, nil)
+		s.Store = store
+		s.DecodeErrorFunc = func(context.Context, error) error {
+			return expectedErr
+		}
+
+		newCtx, err := s.Load(ctx, token)
+		if err != expectedErr {
+			t.Errorf("expected error %v; got %v", expectedErr, err)
+		}
+		if newCtx != nil {
+			t.Error("returned context is unexpectedly not nil")
+		}
 	})
 
 	T.Run("with token hashing", func(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -48,6 +48,13 @@ type SessionManager struct {
 	// a function which logs the error and returns a customized HTML error page.
 	ErrorFunc func(http.ResponseWriter, *http.Request, error)
 
+	// DecodeErrorFunc controls recovery when session data cannot be decoded during
+	// Load. If nil, the decode error is returned. Returning nil deletes the invalid
+	// session and continues with an empty session. Returning an error aborts loading
+	// and returns that error, allowing the decode error to be wrapped or replaced.
+	// The function may also be used for logging or telemetry.
+	DecodeErrorFunc func(context.Context, error) error
+
 	// HashTokenInStore controls whether or not to store the session token or a hashed version in the store.
 	HashTokenInStore bool
 

--- a/session_test.go
+++ b/session_test.go
@@ -91,6 +91,42 @@ func TestEnable(t *testing.T) {
 	}
 }
 
+func TestLoadAndSaveRecoversUndecodableSession(t *testing.T) {
+	t.Parallel()
+
+	sessionManager := New()
+	sessionManager.DecodeErrorFunc = func(ctx context.Context, err error) error {
+		return nil
+	}
+	oldToken := "undecodable-session"
+	expiry := time.Now().Add(time.Hour)
+
+	if err := sessionManager.Store.Commit(oldToken, []byte(""), expiry); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := sessionManager.LoadAndSave(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: sessionManager.Cookie.Name, Value: oldToken})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("expected status %d; got %d", http.StatusNoContent, rr.Code)
+	}
+
+	cookies := rr.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected one expired session cookie; got %d", len(cookies))
+	}
+	if cookies[0].Value != "" || cookies[0].MaxAge >= 0 {
+		t.Errorf("expected the invalid session cookie to be removed; got %q", cookies[0].String())
+	}
+}
+
 func TestLifetime(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #269.

This adds a `DecodeErrorFunc` callback to `SessionManager`, allowing applications to opt into recovery when stored session data cannot be decoded.

By default, behavior remains unchanged: if `DecodeErrorFunc` is nil, `Load()` returns the decode error.

When a callback is configured:

- Returning nil deletes the invalid store entry and continues with a new, empty session. With `LoadAndSave`, the invalid cookie is removed; if the session is subsequently modified, it is committed with a new token.
- Returning an error aborts recovery without deleting the stored session. `Load()` returns the callback’s error, allowing the original decode error to be wrapped or replaced.
- In either case, the callback can log or report the decode error.